### PR TITLE
fix: Undo channel changes

### DIFF
--- a/src/channels.rs
+++ b/src/channels.rs
@@ -1,3 +1,5 @@
+use std::{ops::ControlFlow, sync::Arc};
+
 use tokio::sync::{mpsc, watch};
 
 use super::messages::{BlockMessage, ConfirmTransactionMessage, SendTransactionMessage};
@@ -8,7 +10,7 @@ pub struct Channels {
     pub blockdata_rx: watch::Receiver<BlockMessage>,
     pub transaction_confirmer_tx: mpsc::UnboundedSender<ConfirmTransactionMessage>,
     pub transaction_confirmer_rx: mpsc::UnboundedReceiver<ConfirmTransactionMessage>,
-    pub transaction_sender_tx: mpsc::UnboundedSender<SendTransactionMessage>,
+    pub transaction_sender_tx: Arc<mpsc::UnboundedSender<SendTransactionMessage>>,
     pub transaction_sender_rx: mpsc::UnboundedReceiver<SendTransactionMessage>,
 }
 
@@ -21,6 +23,7 @@ impl Channels {
 
         let (transaction_confirmer_tx, transaction_confirmer_rx) = mpsc::unbounded_channel();
         let (transaction_sender_tx, transaction_sender_rx) = mpsc::unbounded_channel();
+        let transaction_sender_tx = Arc::new(transaction_sender_tx);
 
         Self {
             blockdata_tx,
@@ -31,4 +34,31 @@ impl Channels {
             transaction_sender_rx,
         }
     }
+}
+
+/// Try to send a collection of messages to a [weak sender][`mpsc::WeakUnboundedSender`].
+///
+/// This has four possible outcomes:
+/// - If the channel is closed, no messages are sent and [`ControlFlow::Break`] is returned.
+/// - If the channel is still open, the messages will be sent one at a time:
+///   - If all messages were sent successfully, [`ControlFlow::Continue`] is returned.
+///   - If any of the messages failed to send (which means the channel was closed mid-batch),
+///     the rest of the messages will be dropped and [`ControlFlow::Break`] is returned.
+pub fn upgrade_and_send<T>(
+    sender: &mpsc::WeakUnboundedSender<T>,
+    messages: impl IntoIterator<Item = T>,
+) -> ControlFlow<()> {
+    // First check if there's a receiver on the other end, (even if there are no messages),
+    // to ensure shutdown works as it should.
+    let Some(sender) = sender.upgrade() else {
+        return ControlFlow::Break(());
+    };
+
+    for message in messages {
+        let res = sender.send(message);
+        if res.is_err() {
+            return ControlFlow::Break(());
+        }
+    }
+    ControlFlow::Continue(())
 }


### PR DESCRIPTION
# Description

This PR enhances the shutdown mechanism for the transaction processing system by using weak channel senders. The main changes include:

- Wraps the `transaction_sender_tx` in an `Arc` to allow shared ownership
- Introduces `WeakUnboundedSender` for transaction sender and confirmer channels
- Adds a new `upgrade_and_send` utility function that safely attempts to send messages through weak channels
- Simplifies error handling in the transaction confirmer and sender tasks
- Improves shutdown logic to properly terminate tasks when channels are closed

## Reasoning

This change improves the robustness of the shutdown process by using weak references to channels. This prevents memory leaks and ensures that tasks can properly detect when their communication channels are no longer needed, allowing for cleaner termination.

- [x] Are all new dependencies necessary in `Cargo.toml`necessary?
No new dependencies were added.

## Testing

The existing test suite was updated to use the new weak channel pattern. The tests verify that the transaction sender and confirmer tasks properly handle shutdown signals and channel closures.