### PR TITLE
chore: Update CI tool installation

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -79,22 +79,13 @@ jobs:
           # Nightly is needed for our configuration of cargo fmt
           rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu
 
-      - name: cargo install zepter
+      - name: Install zepter, udeps and just
         uses: taiki-e/install-action@v2
         with:
-          tool: zepter@1
-
-      - name: Install just
-        uses: extractions/setup-just@v3
+          tool: zepter,just,cargo-udeps
 
       - name: Run lint and formatting checks
-        run: just lint
-
-      - name: Install udeps
-        run: cargo install cargo-udeps --locked
-
-      - name: Check for unused dependencies
-        run: just check-udeps
+        run: just lint check-udeps
 
   nextest:
     name: nextest
@@ -103,10 +94,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: taiki-e/install-action@nextest
-
-      - name: Install just
-        uses: extractions/setup-just@v3
+      - name: Install nextest and just
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest,just
 
       - name: Run tests
         run: just test


### PR DESCRIPTION
# Description

## Summary

Streamlined CI workflow by consolidating tool installation steps and simplifying command execution.

## Reasoning

This change improves the GitHub Actions workflow efficiency by:

1. Combining multiple tool installations into a single step using `taiki-e/install-action@v2`
2. Installing `zepter`, `just`, and `cargo-udeps` in one command
3. Merging the lint and dependency check commands into a single `just` command
4. Simplifying the nextest job by installing both nextest and just in one step

These changes reduce the number of separate installation steps and commands, making the workflow more maintainable and potentially faster to execute.