### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/nitro-svm/nitro-sender/compare/v0.1.0...v0.2.0) - 2025-09-11
+
+### Added
+
+- Refactor and improve error propatation
+
+### Other
+
+- Dependency patch
+- Update CI tool installation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1892,7 +1892,7 @@ dependencies = [
 
 [[package]]
 name = "nitro-sender"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nitro-sender"
 description = "A library for sending transactions to the Solana L1 quickly."
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Nitro Labs <team@nitro.technology>"]


### PR DESCRIPTION



## 🤖 New release

* `nitro-sender`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `nitro-sender` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type NitroSender is no longer UnwindSafe, in /tmp/.tmphWxUsE/nitro-sender/src/client.rs:61
  type NitroSender is no longer RefUnwindSafe, in /tmp/.tmphWxUsE/nitro-sender/src/client.rs:61

--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field FailedTransaction.slot in /tmp/.tmphWxUsE/nitro-sender/src/transaction.rs:63

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_variant_added.ron

Failed in:
  variant TransactionOutcome:Unsubmitted in /tmp/.tmphWxUsE/nitro-sender/src/transaction.rs:18
  variant TransactionOutcome:InFlight in /tmp/.tmphWxUsE/nitro-sender/src/transaction.rs:20

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_variant_missing.ron

Failed in:
  variant TransactionOutcome::Unknown, previously in file /tmp/.tmpv6Qgj5/nitro-sender/src/transaction.rs:15

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/method_parameter_count_changed.ron

Failed in:
  nitro_sender::TransactionOutcome::successful now takes 2 parameters instead of 1, in /tmp/.tmphWxUsE/nitro-sender/src/transaction.rs:70
  nitro_sender::TransactionOutcome::into_successful now takes 2 parameters instead of 1, in /tmp/.tmphWxUsE/nitro-sender/src/transaction.rs:87

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/struct_missing.ron

Failed in:
  struct nitro_sender::UnknownTransaction, previously in file /tmp/.tmpv6Qgj5/nitro-sender/src/transaction.rs:30
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/nitro-svm/nitro-sender/compare/v0.1.0...v0.2.0) - 2025-09-11

### Added

- Refactor and improve error propatation

### Other

- Dependency patch
- Update CI tool installation
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).